### PR TITLE
Add DataFusion design documentation

### DIFF
--- a/datafusion_design_notes/execution_engine.md
+++ b/datafusion_design_notes/execution_engine.md
@@ -1,0 +1,33 @@
+# Execution Engine
+
+## Overview
+The execution engine coordinates physical plan execution by scheduling `ExecutionPlan` partitions across threads.
+It relies on the `TaskScheduler` and `RuntimeEnv` abstractions to manage resources and ensure efficient batch
+processing.
+
+## Processing Model
+- **Vectorized, pull-based** execution: Operators request batches from children via async streams.
+- Each partition executes independently, enabling embarrassingly parallel workloads.
+- Supports both `collect()` (materialize in memory) and streaming results through `SendableRecordBatchStream`.
+
+## Pipelining vs. Materialization
+- Most operators pipeline batches directly; materialization occurs when required (e.g., `SortExec`, `HashAggregateExec` for finalization).
+- `RepartitionExec` introduces shuffle boundaries, requiring data redistribution and potential buffering.
+
+## Memory and Resource Management
+- `RuntimeEnv` holds memory manager, disk manager, and object store clients.
+- Spillable operators coordinate with `DiskManager` to avoid out-of-memory scenarios.
+- Configurable concurrency via `SessionConfig::target_partitions` sets default partition count for parallelism.
+
+## Task Scheduling
+- Local execution uses a cooperative async runtime (Tokio) to poll operator futures.
+- For distributed Ballista runtime, scheduler assigns tasks to executors using work-stealing and monitors progress via heartbeats.
+- Fine-grained metrics collected per task to feed monitoring and adaptive behaviors.
+
+## Fault Tolerance
+- Single-node DataFusion relies on upstream error propagation; failures bubble to clients.
+- Ballista introduces retry logic for failed tasks, rescheduling partitions as needed.
+
+## Improvement Opportunities
+- Introduce adaptive execution (dynamic repartitioning based on runtime stats).
+- Explore integration with Arrow Flight SQL for streaming results with backpressure control.

--- a/datafusion_design_notes/expression_evaluation.md
+++ b/datafusion_design_notes/expression_evaluation.md
@@ -1,0 +1,77 @@
+# Expression Evaluation
+
+## Overview
+Expression evaluation underpins DataFusion's performance. Logical expressions (`Expr`) are compiled into
+`PhysicalExpr` implementations executed against Arrow `RecordBatch`es. The engine emphasizes vectorized
+interpretation with optional code generation for Substrait/externals, balancing flexibility and speed.
+
+## Expression AST Structure
+- Logical expressions modeled via `Expr` enum in `datafusion-expr`, covering columns, literals, binary/ternary ops,
+  scalar/aggregate/window functions, casts, case expressions, and subqueries.
+- Physical expressions implement `PhysicalExpr` trait with `evaluate(&self, batch)` returning `ColumnarValue`.
+- Visitor utilities like `ExprVisitor` enable traversing expressions for analysis (e.g., column collection).
+
+## Type System and Coercion
+- `DataType` enumeration from Arrow defines supported types; DataFusion extends semantics via `DataFusionError`
+  for unsupported casts or operations.
+- `TypeCoercion` module computes common supertypes for binary operators, aligning with SQL rules (numeric promotion,
+  string concatenation, boolean logic).
+- Implicit casting occurs during logical planning; runtime evaluation uses explicit `CastExpr` nodes.
+
+## Operators and Extensibility
+- Operators enumerated in `Operator` (arithmetic, comparison, boolean). Each maps to compute kernels in Arrow.
+- New operators require extending `Operator` enum, implementing physical evaluation using Arrow kernels, and updating
+  planner coercion logic.
+- Complex expressions (e.g., `IN`, `LIKE`, regex) implemented via specialized `ScalarFunctionExpr` wrappers.
+
+## Type Casting and Error Handling
+- `CastExpr` checks validity and uses Arrow's `compute::cast` kernels; errors propagate as `DataFusionError::Execution`.
+- Overflow detection depends on Arrow kernels (e.g., `checked_add`) to return errors when overflow occurs.
+- Division by zero results in Arrow errors; DataFusion surfaces them to the query engine for proper handling.
+
+## Evaluation Modes
+- **Vectorized interpretation**: Default mode; each `PhysicalExpr` evaluates entire batch via Arrow kernels.
+- **Scalar fallback**: For expressions lacking vectorized kernels, DataFusion iterates row-wise using `ScalarValue` utilities.
+- **Code generation**: Experimental via Substrait and external projects (e.g., using LLVM) to compile expressions into
+  native code for specific targets.
+
+## Vectorized Details
+- Batch size configurable (default 8192). `ColumnarValue` returns either an array or scalar broadcast.
+- SIMD usage delegated to Arrow compute kernels; DataFusion benefits automatically when compiled with CPU feature flags.
+- Loop unrolling achieved within Arrow kernels; DataFusion focuses on minimizing per-row dispatch overhead.
+
+## Scalar Function Evaluation
+- Built-in scalar functions registered via `ScalarUDF`. Each has a `Signature`, `ReturnTypeFunction`, and `ScalarFunctionImplementation`.
+- Implementations typically call Arrow kernels; for complex cases (e.g., regex), rely on `regex` crate compiled iterators.
+- UDFs can be registered at runtime by providing closures conforming to `ScalarUDF` API.
+
+## Aggregate Function Evaluation
+- Aggregate expressions represented by `AggregateExpr` trait implementations (`Sum`, `Avg`, `Min`, `Max`, `ApproxDistinct`).
+- Partial aggregation uses accumulator structs implementing `Accumulator` trait with `update_batch`, `merge_batch`, `evaluate`.
+- Hash aggregate organizes accumulators per group key; supports two-phase (partial/final) execution for distributed contexts.
+
+## Window Function Evaluation
+- Implemented via `WindowAggExec` combining partitioning, ordering, and frame specifications.
+- Uses sliding accumulators and partition-boundary detection to compute window results efficiently.
+- Supports row-based and range-based frames; ongoing work extends to groups-based frames.
+
+## User-Defined Functions
+- Scalar UDFs registered through `SessionContext::register_udf`. DataFusion ensures type checking using signatures.
+- Aggregate UDFs implement `AggregateUDF` with custom accumulators; state serialization supports distributed merges.
+- User-Defined Table Functions (UDTF) emerging via `TableFunction` trait for generating relation-valued outputs.
+
+## Optimization Techniques
+- `SimplifyExpressions` rule performs constant folding, boolean simplification, and canonicalization.
+- Common subexpression elimination supported via `ExprRewriter` visitors caching evaluation results across projections.
+- `Repartition` and `CoalesceBatches` operators used to align batch sizes and reduce redundant evaluations.
+
+## Error Handling
+- Evaluation errors propagate as `DataFusionError::Execution`, captured per task and aggregated at query level.
+- Configurable to continue on error for some data sources (e.g., `CsvOptions::skip_invalid_rows`).
+- Null semantics preserved using Arrow's three-valued logic across logical and physical layers.
+
+## Performance Considerations
+- Benchmarks show vectorized evaluation achieving millions of rows/sec on modern CPUs due to Arrow kernels.
+- Bottlenecks include dynamic dispatch overhead for `PhysicalExpr` trait objects and limited code generation.
+- Proposed improvements: expression fusion to reduce kernel launches, caching compiled expressions via JIT, and
+  integrating hardware-specific kernels (AVX-512, GPU) through Arrow extensions.

--- a/datafusion_design_notes/index.md
+++ b/datafusion_design_notes/index.md
@@ -1,0 +1,30 @@
+# DataFusion Design Notes
+
+This collection summarizes key architectural components of Apache DataFusion, a Rust-based query execution
+framework built on Apache Arrow. Each section distills implementation details, design trade-offs, and improvement
+ideas derived from the upstream project, focusing particularly on the expression evaluation subsystem.
+
+## Component Guide
+
+- [Tech Stack](tech_stack.md)
+- [SQL Frontend](sql_frontend.md)
+- [Metadata Management](metadata_management.md)
+- [Logical Plan](logical_plan.md)
+- [Optimizer](optimizer.md)
+- [Physical Plan](physical_plan.md)
+- [Memory Layout](memory_layout.md)
+- [Expression Evaluation](expression_evaluation.md)
+- [Execution Engine](execution_engine.md)
+- [Runtime](runtime.md)
+- [Storage Integration](storage_integration.md)
+- [Monitoring and Diagnostics](monitoring_diagnostics.md)
+
+## Research Notes
+
+- Expression evaluation is the primary performance lever in DataFusion. The subsystem balances Arrow-native
+  vectorized kernels with extensible UDFs, while exploring optional code generation via the DataFusion Substrait
+  bridge and potential LLVM integration.
+- Optimizer capabilities have evolved from purely rule-based rewrites toward selective cost-based decisions using
+  statistics providers, though the system still leans heavily on heuristics.
+- Distributed execution through Ballista shares many components with core DataFusion but introduces scheduling and
+  shuffle services that can inspire future runtime work.

--- a/datafusion_design_notes/logical_plan.md
+++ b/datafusion_design_notes/logical_plan.md
@@ -1,0 +1,41 @@
+# Logical Plan
+
+## Overview
+DataFusion represents logical plans using the `LogicalPlan` enum defined in `datafusion-optimizer`.
+Plans are immutable trees built via builder APIs and SQL translation, enabling rule-based optimization
+before conversion to physical plans.
+
+## Node Types
+- `Projection`, `Filter`, `Aggregate`, `Join`, `Sort`, `Limit`, `Repartition`, `Union`, `Distinct`, `Window`, and `Explain`.
+- `TableScan` nodes wrap `TableSource` metadata including projection pushdown, filters, and statistics.
+- `Subquery` nodes handle CTEs, scalar subqueries, and derived tables.
+
+## Representation Patterns
+- The enum-based representation leverages Rust's pattern matching for rule definitions.
+- Expressions use `Expr` enum with variants like `Column`, `Literal`, `BinaryExpr`, `Case`, and `AggregateFunction`.
+- Helper builders (`LogicalPlanBuilder`) provide fluent APIs to compose plans from DataFrame operations.
+
+## Translation Flow
+1. SQL parsed into AST via `sqlparser-rs`.
+2. `SqlToRel` converts statements to `LogicalPlan` using context to resolve schemas and functions.
+3. DataFrame API constructs plans directly (e.g., `df.filter(col("x").gt(lit(1)))`).
+
+## Rewrite Rules
+- Rule list managed by `Optimizer` includes passes for projection pushdown, predicate pushdown, constant folding,
+  type coercion, filter reordering, and join reordering heuristics.
+- Rules implement `OptimizerRule` trait with `optimize(&self, plan, state)` returning transformed plan.
+- Applying a rule requires matching plan patterns using tree visitor functions and rewriting subtrees.
+
+## Adding a New Rule
+1. Implement `OptimizerRule` in a new module (e.g., `optimizer/src/rules`).
+2. Use helper macros like `plan_rewrite` or manual recursion to locate target patterns.
+3. Register the rule in `Optimizer::new()` sequence, placing it relative to dependent transformations.
+4. Add unit tests under `optimizer/src/rules/tests` verifying canonical inputs and outputs.
+
+## Expression Simplification
+- Constant folding occurs in both logical expressions (`simplify_expressions` rule) and aggregator contexts.
+- `ExprSimplifier` uses data type information from schemas to reduce arithmetic and boolean expressions.
+
+## Improvement Opportunities
+- Explore memoized plan representation (e.g., Cascades or DPhyp) for cost-based optimization.
+- Extend statistics propagation to improve selectivity estimates feeding join reordering decisions.

--- a/datafusion_design_notes/memory_layout.md
+++ b/datafusion_design_notes/memory_layout.md
@@ -1,0 +1,36 @@
+# Memory Layout
+
+## Overview
+DataFusion relies on Apache Arrow's columnar memory format, inheriting its contiguous buffers, validity bitmaps,
+and offset arrays. Operators process data in batches of Arrow `RecordBatch` objects to maximize cache locality and
+SIMD efficiency.
+
+## Data Representation
+- Columnar arrays store values contiguously per column; nested types use offset and value buffers.
+- Scalar values represented via Arrow primitives (e.g., `Int64Array`, `Float64Array`). Strings use `BinaryArray` with
+  offset buffers.
+- Struct and list types supported through Arrow's nested array abstractions, enabling semi-structured data.
+
+## Buffer Management
+- Memory allocations handled via `arrow::buffer::Buffer` and `MutableBuffer`, backed by aligned allocations.
+- `MemoryManager` in DataFusion enforces per-query and global memory limits; integrates with `RuntimeEnv`.
+- Spill support uses `DiskManager` to offload oversized buffers for sort/aggregate operations.
+
+## Null Handling
+- Validity bitmaps accompany each array, enabling branch-free null checks via bitwise operations.
+- Kernels propagate null semantics using Arrow's compute utilities, ensuring three-valued logic.
+- `BooleanArray` specialized for bit-packed storage to reduce memory footprint.
+
+## Compression and Encoding
+- In-memory buffers are uncompressed; compression handled at storage layer (e.g., Parquet encoding).
+- Dictionary encoding supported via `DictionaryArray` to reduce memory for low-cardinality columns.
+- Run-length encoding handled within Parquet reader, expanded into Arrow arrays during execution.
+
+## Vectorized Batch Processing
+- Default batch size configurable (`config.batch_size`, typically 8192 rows).
+- Operators iterate over `RecordBatch` streams, enabling vectorized compute kernels like `arrow::compute::add`.
+- Evaluation can leverage SIMD (AVX2, NEON) via Arrow's compute module when compiled with appropriate features.
+
+## Improvement Opportunities
+- Investigate in-memory compression for intermediate results (e.g., dictionary re-encoding post-filter).
+- Explore GPU device memory management integration to keep Arrow buffers resident on accelerators.

--- a/datafusion_design_notes/metadata_management.md
+++ b/datafusion_design_notes/metadata_management.md
@@ -1,0 +1,33 @@
+# Metadata Management
+
+## Overview
+Metadata in DataFusion is centered on the `CatalogProvider`, `SchemaProvider`, and `TableProvider` traits,
+which abstract storage backends and expose schema information to planners and execution components.
+
+## Table and Schema Storage
+- **CatalogProvider** manages named catalogs (default `datafusion`). Implementations can back onto in-memory maps,
+  Hive Metastore, Glue, or custom registries.
+- **SchemaProvider** stores collections of tables within a catalog. The default implementation is memory-backed.
+- **TableProvider** exposes logical schema, statistics, and execution plans for a table. Concrete implementations include
+  `ListingTable` (object storage files), `MemoryTable`, `ParquetExec`, and external connectors.
+
+## Name Resolution
+- The logical planner uses `DFSchema` and `DFField` to manage column qualification, including aliases and wildcard expansion.
+- Resolves identifiers via `SessionState`'s catalog list, falling back to default catalog/schema when unspecified.
+- Supports temporary views and CTEs stored in session-specific state maps.
+
+## Caching Strategies
+- **TableProvider::statistics** enables caching file-level metadata (e.g., row count, byte size) for pruning.
+- `ListingTableCache` caches file listings per table to avoid repeated object store scans.
+- Session-level caches store prepared statements and logical plan representations for repeated queries.
+
+## External Integrations
+- Hive-style partition discovery supported via directory structure parsing in `ListingTableUrl`. Partition columns
+  inferred and appended to schema metadata.
+- AWS/GCP/Azure object stores supported through `object_store` crate implementations, enabling credential injection
+  and secure metadata access.
+- Integration with DataFusion's catalog service in Ballista enables cluster-wide metadata synchronization.
+
+## Improvement Opportunities
+- Introduce unified metadata snapshotting to coordinate statistics and schema versions across distributed executors.
+- Provide incremental refresh strategies (e.g., event-based updates) to reduce latency in catalog changes.

--- a/datafusion_design_notes/monitoring_diagnostics.md
+++ b/datafusion_design_notes/monitoring_diagnostics.md
@@ -1,0 +1,30 @@
+# Monitoring and Diagnostics
+
+## Overview
+Observability features in DataFusion provide insight into query execution through logging, metrics, and
+plan explainers. These tools aid performance tuning and troubleshooting.
+
+## Logging
+- Uses Rust `log` facade with env_logger or tracing subscribers for structured output.
+- Execution events logged at debug level include plan creation, optimizer passes, and operator scheduling.
+- Ballista extends logging with job lifecycle events and executor status updates.
+
+## Metrics
+- `MetricSet` attached to `ExecutionPlan` nodes collects counters (input/output rows, batches), gauges (peak memory),
+  and timings (elapsed compute). Metrics aggregated per partition and exposed via `ExecutionMetrics`.
+- Optional integration with `metrics` crate enables exporting to Prometheus or other backends.
+- Ballista exposes REST/gRPC endpoints for cluster-wide metrics collection.
+
+## Explain and Analyze
+- `EXPLAIN` statement returns logical and physical plan text along with optimizer rule application traces.
+- `EXPLAIN ANALYZE` executes the query and returns collected metrics embedded in the plan tree.
+- JSON representation of plans available via `display::plan` utilities for programmatic consumption.
+
+## Profiling and Debugging
+- Feature flags enable tracing with `tokio-tracing` to capture spans per operator.
+- Integration with `pprof` crate allows CPU and heap profiling snapshots.
+- Unit and integration tests include `assert_batches_eq!` macros to validate execution correctness.
+
+## Improvement Opportunities
+- Provide query timeline visualization aggregating metrics over time for long-running queries.
+- Add event-driven alerts for skew detection or repeated spills to disk.

--- a/datafusion_design_notes/optimizer.md
+++ b/datafusion_design_notes/optimizer.md
@@ -1,0 +1,37 @@
+# Optimizer
+
+## Overview
+DataFusion ships with a primarily rule-based optimizer that performs logical rewrites and limited cost-based
+choices. The optimizer is extensible via pluggable rules and statistics providers.
+
+## Rule-Based Optimization
+- Rules implement the `OptimizerRule` trait and are executed in a configurable pipeline.
+- Key rules: projection pruning, predicate pushdown, filter simplification, constant folding, type coercion,
+  limit pushdown, `IN` list simplification, and join reorder heuristics.
+- Pattern matching utilities (e.g., `OptimizerUtils::extract_columns`) help rules interact with expressions.
+
+## Cost-Based Elements
+- Statistics derived from `TableProvider::statistics` feed into `JoinSelection` rule to choose join algorithm
+  (hash vs. nested loop) and order.
+- Column statistics (min/max, null count) used for selectivity estimation in predicate pushdown and pruning.
+- `OptimizerConfig` allows enabling cost-based decisions selectively (e.g., for distributed contexts).
+
+## Statistics Collection
+- `StatisticsProvider` trait fetches table-level and column-level metrics.
+- Parquet reader extracts metadata (row groups, min/max) and surfaces through statistics to the optimizer.
+- Users can plug custom providers for external catalogs; caching recommended for expensive metadata retrieval.
+
+## Join Reordering
+- Default heuristic uses commutativity/associativity rewrites to explore bushy trees limited by plan size.
+- Cost-based reordering uses greedy algorithms, evaluating join selectivity from stats to choose best pairings.
+- Support exists for broadcast hints via config or SQL hints to influence join type selection.
+
+## Predicate Pushdown & Projection Pruning
+- Performed across TableScan, Projection, and Aggregate nodes.
+- Table providers expose `supports_filters_pushdown` to indicate supported filter types (exact, inexact, unsupported).
+- Projection pruning uses expression analysis to compute required columns, reducing I/O and compute.
+
+## Improvement Opportunities
+- Introduce a memo-based optimizer (e.g., Cascades) to unify rule application and cost estimation.
+- Expand statistics to include histograms and ndv estimates for more accurate selectivity.
+- Provide adaptive runtime feedback loops to refine optimizer decisions based on observed execution metrics.

--- a/datafusion_design_notes/physical_plan.md
+++ b/datafusion_design_notes/physical_plan.md
@@ -1,0 +1,37 @@
+# Physical Plan
+
+## Overview
+Physical plans in DataFusion are represented by implementations of the `ExecutionPlan` trait defined in the
+`datafusion-physical-plan` crate. Plans are vectorized operators that produce Arrow `RecordBatch` streams.
+
+## Node Types
+- **Scan Operators**: `ParquetExec`, `CsvExec`, `JsonExec`, `AvroExec`, `ListingTableExec`.
+- **Relational Operators**: `ProjectionExec`, `FilterExec`, `HashAggregateExec`, `SortExec`, `WindowAggExec`,
+  `LimitExec`, `CrossJoinExec`, `HashJoinExec`, `NestedLoopJoinExec`.
+- **Utility Operators**: `CoalescePartitionsExec`, `RepartitionExec`, `MergeExec`, `ExplainExec`, `AnalyzeExec`.
+
+## Representation
+- Each plan implements `ExecutionPlan` trait methods: `schema()`, `output_partitioning()`, `children()`, and
+  `execute(partition, context)` returning async stream of `RecordBatch`.
+- Plans compose via trait objects (`Arc<dyn ExecutionPlan>`), enabling runtime polymorphism.
+- `PhysicalExpr` trait mirrors logical expressions for evaluation on batches.
+
+## Execution Model
+- Operators follow a vectorized iterator pattern, pulling batches from children via async streams.
+- Execution context orchestrated by `TaskContext` which carries runtime state, memory managers, and session configs.
+- Partitioning metadata guides scheduler decisions: `Unbounded`, `Hash`, `RoundRobin`, `UnknownPartitioning`.
+
+## Hardware Integration
+- Arrow kernels provide SIMD-optimized primitives for arithmetic, comparisons, and aggregations.
+- GPU integration is experimental; DataFusion relies on Arrow's device-agnostic buffers and is exploring partnerships
+  with projects like Arrow CUDA or external accelerators.
+- Supports spilling to disk via `DiskManager` when memory limits are hit during sort or aggregate operations.
+
+## Logical-to-Physical Translation
+- `PhysicalPlanner` trait transforms `LogicalPlan` into physical plans, invoking `DefaultPhysicalPlanner` by default.
+- Table providers supply custom `create_physical_plan` to inject specialized operators.
+- Physical expression planner (`create_physical_expr`) converts logical expressions respecting type coercion rules.
+
+## Improvement Opportunities
+- Adopt adaptive batch sizing based on downstream backpressure and Arrow compute kernel throughput.
+- Explore asynchronous prefetch for file scans to overlap I/O and compute within executors.

--- a/datafusion_design_notes/runtime.md
+++ b/datafusion_design_notes/runtime.md
@@ -1,0 +1,30 @@
+# Runtime
+
+## Overview
+DataFusion's runtime environment (`RuntimeEnv`) encapsulates thread pools, memory management, disk spill
+configuration, and object store clients. It powers both standalone execution and distributed Ballista deployments.
+
+## Asynchronous Operations
+- Built on **Tokio** async runtime for scheduling futures representing operator execution.
+- File readers (Parquet, CSV) use async I/O when available; blocking tasks executed via dedicated thread pools to
+  avoid stalling async reactor.
+- Ballista leverages async gRPC (Tonic) for scheduler-executor communication.
+
+## Operator Scheduling
+- Single-node mode uses a task-per-partition model executed on a shared thread pool.
+- Ballista scheduler assigns tasks to executors, employing work-stealing to balance load.
+- Configurable concurrency via `RuntimeConfig::worker_threads` allows tuning per deployment.
+
+## Parallelism Models
+- Intra-query parallelism achieved by partitioning input scans and distributing across worker threads.
+- Hash and sort aggregates support multi-stage execution (partial + final) to exploit partition-level parallelism.
+- Ballista adds inter-node parallelism with shuffle stages persisted via object store or Flight.
+
+## Distributed Execution
+- Ballista's architecture includes scheduler, executors, and persistent state (etcd or memory) for tracking jobs.
+- Data shuffling implemented with Arrow Flight or object store intermediates (e.g., S3), enabling fault tolerance.
+- Supports task retries, speculative execution (configurable), and executor heartbeats for liveness.
+
+## Improvement Opportunities
+- Integrate adaptive resource scaling for elastic cloud environments based on workload intensity.
+- Explore cooperative cancellation propagation across tasks to reduce wasted work on query aborts.

--- a/datafusion_design_notes/sql_frontend.md
+++ b/datafusion_design_notes/sql_frontend.md
@@ -1,0 +1,38 @@
+# SQL Frontend
+
+## Overview
+DataFusion exposes a SQL interface that translates SQL-92 compatible statements into logical plans using the
+`sqlparser-rs` library and the `datafusion-sql` crate. The frontend is extensible, enabling custom functions and
+statements while keeping close parity with Arrow DataFrame semantics.
+
+## Parser Implementation
+- Uses **`sqlparser-rs`** for lexical analysis and AST generation. DataFusion extends the parser with custom dialects
+  for features like `SHOW TABLES`, `DESCRIBE`, and `CREATE EXTERNAL TABLE`.
+- The SQL planner converts `sqlparser::ast::Statement` nodes into DataFusion logical plan nodes through the
+  `SqlToRel` struct, mapping expressions recursively.
+
+## Extensions and Custom Syntax
+- Supports statements for data source registration (`CREATE EXTERNAL TABLE`, `CREATE VIEW`).
+- Provides session-specific commands like `SET VARIABLE` and `CREATE FUNCTION` for scalar UDF registration.
+- Recognizes DataFusion-specific COPY statements for CSV and Parquet ingestion in CLI contexts.
+
+## Compliance and Feature Set
+- Targets **SQL-92** compatibility with incremental support for newer constructs (e.g., `UNNEST`, `LATERAL VIEW`).
+- Supports common DDL/DML: `SELECT`, `INSERT`, `UPDATE` (limited), `DELETE` (when table providers expose delete handles).
+- Offers scalar, aggregate, and window functions aligned with ANSI SQL naming where possible.
+
+## Built-in Functions
+- Scalar functions implemented under `datafusion-expr/src/expr_fn.rs` and `datafusion-functions` modules include
+  arithmetic, string, datetime, math, and conditional operators.
+- Aggregate functions like `SUM`, `AVG`, `APPROX_DISTINCT`, `GROUPING` defined through `AggregateUDF` interfaces.
+- Window functions (e.g., `ROW_NUMBER`, `RANK`, `LEAD/LAG`) reuse aggregate kernels with partition/order metadata.
+
+## AST Structure
+- `sqlparser-rs` AST includes enums such as `Statement`, `Expr`, `Query`, and `SelectItem`.
+- DataFusion introduces wrapper enums (`DFSchema`, `DFField`) to bridge SQL identifiers with logical plan schemas.
+- Visitor pattern implemented through `SqlToRel::sql_to_relation` and helper functions to traverse expressions,
+  performing type coercion and name resolution during translation.
+
+## Improvement Ideas
+- Investigate parser-level hints or annotations (e.g., optimizer hints) to guide rule selection.
+- Expand dialect support for ANSI SQL 2016 analytics, particularly advanced window framing and JSON features.

--- a/datafusion_design_notes/storage_integration.md
+++ b/datafusion_design_notes/storage_integration.md
@@ -1,0 +1,35 @@
+# Storage Integration
+
+## Overview
+DataFusion integrates with multiple storage formats and services, leveraging Apache Arrow for columnar transport
+and the `object_store` abstraction for cloud-native data access.
+
+## Supported File Formats
+- **Parquet**: Primary columnar format with predicate and projection pushdown via metadata statistics.
+- **CSV**: Flexible ingestion with schema inference, header detection, and delimiter customization.
+- **JSON**: Line-delimited JSON reader for semi-structured data.
+- **Avro**: Reader leveraging Apache Avro schema evolution support.
+- **IPC/Arrow**: Direct consumption of Arrow file and stream formats.
+
+## Columnar Optimizations
+- Parquet reader leverages row group pruning, column chunk selection, and async prefetching.
+- Uses Arrow's columnar arrays to minimize deserialization overhead.
+- Supports dictionary re-use and encoding-aware conversions to reduce CPU cost.
+
+## Object Store Abstraction
+- `object_store::ObjectStore` trait wraps cloud storage (S3, GCS, Azure Blob) and local filesystems.
+- Listing tables via `ListingTable` unify path-based datasets across stores with partition discovery.
+- Credentials and retry policies configured through `ObjectStoreUrl` and runtime environment.
+
+## Partitioning and Indexing
+- Hive-style directory partitioning automatically mapped to schema columns.
+- Parquet metadata caches store file-level statistics for partition pruning.
+- Lacks built-in secondary indexing; relies on partitioning and data layout for pruning.
+
+## Compression
+- Parquet compression codecs (Snappy, Gzip, Zstd, Brotli) supported through `parquet` crate.
+- CSV/JSON support gzip-compressed sources via async streams with decompression wrappers.
+
+## Improvement Opportunities
+- Add support for Delta Lake and Iceberg table metadata for ACID semantics.
+- Introduce materialized view management with incremental refresh leveraging object store notifications.

--- a/datafusion_design_notes/tech_stack.md
+++ b/datafusion_design_notes/tech_stack.md
@@ -1,0 +1,35 @@
+# Tech Stack
+
+## Overview
+DataFusion is implemented primarily in Rust and leverages Apache Arrow as its in-memory columnar format.
+The project ships both a core query engine and optional distributed runtime (Ballista) with consistent data
+structures and planner components.
+
+## Programming Languages and Core Libraries
+- **Rust** for all core modules, leveraging traits, enums, and async features for type safety and performance.
+- **Apache Arrow Rust crate** (`arrow` and `arrow-array`) for columnar buffers, array kernels, and IPC support.
+- **Arrow Flight** (`arrow-flight`) to provide gRPC-based transport for distributed execution scenarios.
+- **Parquet** (`parquet` crate) for columnar file read/write integration.
+
+## Build and Packaging
+- Built with **Cargo**, with workspaces dividing crates such as `datafusion-common`, `datafusion-expr`, `datafusion-optimizer`,
+  and `datafusion-physical-plan` for modular compilation.
+- Integration tests orchestrated via `cargo test` across workspace members; optional features enable subcomponents like
+  DataFrame API, SQL planner, or Ballista runtime.
+- Continuous integration uses GitHub Actions to run Rust unit tests, fmt, clippy, and integration pipelines.
+
+## External Dependencies
+- Depends on **Tokio** for async runtime primitives used by executors, data sources, and Ballista scheduler.
+- Utilizes **prost** and **tonic** through Arrow Flight for protocol buffers and gRPC communication.
+- Optional integration with **object store** crates (e.g., `object_store`) for cloud storage abstraction.
+- Supports Substrait serialization via the `datafusion-substrait` crate for interoperability.
+
+## Versioning and Compatibility
+- Tracks Arrow releases closely; Cargo features gate compatibility with specific Arrow versions.
+- Semantic versioning adopted with `datafusion` crates publishing under the Apache Software Foundation release process.
+- Stability guarantees prioritize logical/physical plan APIs while allowing experimental features (e.g., async functions,
+  `TableProvider` extensions) behind feature flags.
+
+## Opportunities
+- Evaluate embedding MLIR or other IR frameworks for code generation to improve performance-critical kernels.
+- Explore `no_std` compatibility for embedded deployments by isolating OS-dependent components (e.g., object store, networking).


### PR DESCRIPTION
## Summary
- add a DataFusion design notes index and component-specific markdown files
- document architecture across tech stack, planner, execution, runtime, and observability with focus on expression evaluation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7a7ccb2a8832e9889f37e217d0cc1